### PR TITLE
Fixed link, added more links and copyright

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,5 +5,22 @@ Stingray Notebooks
     :target: http://mybinder.org/repo/StingraySoftware/notebooks
 
 This repository contains Jupyter notebooks with tutorials and
-examples of the timing software package
-`stingray <https://github.com/StingraySoftware/stingray/issues>`_ !
+examples of the spectral-timing library
+`Stingray <https://github.com/StingraySoftware/stingray>`_!
+The main Stingray website is 
+`here <http://stingraysoftware.github.io/>`_, 
+and the Stingray documentation is hosted at 
+`readthedocs <https://stingray.readthedocs.io/>`_.
+
+Click on the above 'launch binder' button to view and run the notebooks on 
+a remote server.
+
+Copyright
+=========
+All content © 2015 the authors. The code is distributed under the MIT license.
+
+`Pull requests <https://github.com/StingraySoftware/notebooks/pulls>`_ 
+are welcome! If you find a bug, think something could use clarifying, 
+or are generally interested in the further development of this project, 
+please get in touch via the 
+`issues <https://github.com/StingraySoftware/notebooks/issues>`_!


### PR DESCRIPTION
Fixed the Stingray library link, added links to the main website, documentation, pull requests, and issues, and added a statement on the copyright/license (pretty much copy/pasted from the main stingray repo README).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/notebooks/20)
<!-- Reviewable:end -->
