### PR TITLE
Added from future statement to make notebooks more python2 friendly

### DIFF
--- a/Bispectrum/bispectrum_tutorial.ipynb
+++ b/Bispectrum/bispectrum_tutorial.ipynb
@@ -37,6 +37,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "from stingray import lightcurve\n",
     "import numpy as np\n",
     "from stingray.bispectrum import Bispectrum\n",

--- a/CrossCorrelation/cross_correlation_notebook.ipynb
+++ b/CrossCorrelation/cross_correlation_notebook.ipynb
@@ -17,6 +17,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from stingray import Lightcurve\n",
     "from stingray.crosscorrelation import CrossCorrelation\n",

--- a/Crossspectrum/Crossspectrum_tutorial.ipynb
+++ b/Crossspectrum/Crossspectrum_tutorial.ipynb
@@ -22,6 +22,7 @@
     }
    ],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from stingray import Lightcurve, Crossspectrum, AveragedCrossspectrum\n",
     "\n",

--- a/DynamicalPowerspectrum/DynamicalPowerspectrum_tutorial_[fake_data].ipynb
+++ b/DynamicalPowerspectrum/DynamicalPowerspectrum_tutorial_[fake_data].ipynb
@@ -15,6 +15,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "%matplotlib inline"
    ]
   },

--- a/DynamicalPowerspectrum/DynamicalPowerspectrum_tutorial_[real_data].ipynb
+++ b/DynamicalPowerspectrum/DynamicalPowerspectrum_tutorial_[real_data].ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "%matplotlib inline"
    ]
   },

--- a/EventList/EventList Tutorial.ipynb
+++ b/EventList/EventList Tutorial.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "\n",
     "from matplotlib import pyplot as plt\n",

--- a/Lightcurve/Analyze light curves chunk by chunk - an example.ipynb
+++ b/Lightcurve/Analyze light curves chunk by chunk - an example.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "%matplotlib inline \n",

--- a/Lightcurve/Lightcurve tutorial.ipynb
+++ b/Lightcurve/Lightcurve tutorial.ipynb
@@ -15,6 +15,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "%matplotlib inline"
    ]

--- a/Modeling/ModelingExamples.ipynb
+++ b/Modeling/ModelingExamples.ipynb
@@ -26,6 +26,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/Powerspectrum/Powerspectrum_tutorial.ipynb
+++ b/Powerspectrum/Powerspectrum_tutorial.ipynb
@@ -22,6 +22,7 @@
     }
    ],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from stingray import Lightcurve, Powerspectrum, AveragedPowerspectrum\n",
     "\n",

--- a/Pulsar/Pulsar search with epoch folding and Z squared.ipynb
+++ b/Pulsar/Pulsar search with epoch folding and Z squared.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "%matplotlib notebook\n",

--- a/Simulator/Concepts/Inverse Transform Sampling.ipynb
+++ b/Simulator/Concepts/Inverse Transform Sampling.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "import numpy.random as ra\n",

--- a/Simulator/Concepts/PowerLaw Spectrum.ipynb
+++ b/Simulator/Concepts/PowerLaw Spectrum.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "\n",

--- a/Simulator/Concepts/Simulator.ipynb
+++ b/Simulator/Concepts/Simulator.ipynb
@@ -37,6 +37,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "from stingray import Crossspectrum, Lightcurve, sampledata\n",
     "import numpy as np\n",
     "from scipy import signal\n",

--- a/Simulator/Lag Analysis.ipynb
+++ b/Simulator/Lag Analysis.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline"

--- a/Simulator/Simulator Tutorial.ipynb
+++ b/Simulator/Simulator Tutorial.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline"

--- a/Simulator/Spectral Models.ipynb
+++ b/Simulator/Spectral Models.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "from stingray.simulator import simulator, models"
    ]
   },

--- a/Transfer Functions/Data Preparation.ipynb
+++ b/Transfer Functions/Data Preparation.ipynb
@@ -8,6 +8,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline"

--- a/Transfer Functions/TransferFunction Tutorial.ipynb
+++ b/Transfer Functions/TransferFunction Tutorial.ipynb
@@ -36,6 +36,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline"

--- a/Window Functions/window_functions.ipynb
+++ b/Window Functions/window_functions.ipynb
@@ -39,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function, division, with_statement, absolute_import, generators, nested_scopes\n",
     "from stingray.utils import create_window\n",
     "\n",
     "from scipy.fftpack import fft, fftshift, fftfreq\n",


### PR DESCRIPTION
In the notebooks ,
from **future**  statement has been added to add the following features to make them more python2 friendly :

1)print_function,
2)division,
3)with_statement,
4)absolute_import,
5)generators,
6)nested_scopes

*Importing unicode_literals has been avoided as it changes the data types of all strings.*

 Cannot reopen the earlier pull request as I had to force push my master branch.
@matteobachetti Can you review it?Please do let me know if there is any problem
 Thanks :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stingraysoftware/notebooks/28)
<!-- Reviewable:end -->
