### PR TITLE
Fixed reference error in PDM notebooks

### DIFF
--- a/Pulsar/Phase Dispersion Minimization.ipynb
+++ b/Pulsar/Phase Dispersion Minimization.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Phase Dispersion Minimization in Stingray\n",
     "\n",
-    "Phase dispersion minimization (PDM; [Stellingwerf (1978)]) is a method to search for strictly periodic signals in constant light curves (white noise only). Like Epoch Folding, it relies in folding a light curve at a given trial period, splitting the folded light curve into phase bins, and evaluating the resulting profile. \n",
+    "Phase dispersion minimization (PDM; Stellingwerf (1978)) is a method to search for strictly periodic signals in constant light curves (white noise only). Like Epoch Folding, it relies in folding a light curve at a given trial period, splitting the folded light curve into phase bins, and evaluating the resulting profile. \n",
     "\n",
     "Epoch Folding evaluates how much the means in each phase bin deviate from the global sample mean, given the variance of the measurements. A periodic signal will generate a maximum in the Epoch Folding periodogram across many trial periods. In contrast, Phase Dispersion Minimization evaluates the *variance* in each phase bin and compares this to the global sample variance $\\hat{\\sigma}$:\n",
     "\n",
@@ -213,7 +213,7 @@
    "source": [
     "A dip is definitely there at the frequency we expect it to be. \n",
     "\n",
-    "Unlike the Epoch Folding statistic, which follows approximately a $\\chi^2$ distribution, the PDM statistic was shown to follow a beta-distribution ([Schwarzenberg-Czerny, 1997]()). \n",
+    "Unlike the Epoch Folding statistic, which follows approximately a $\\chi^2$ distribution, the PDM statistic was shown to follow a beta-distribution (Schwarzenberg-Czerny, 1997). \n",
     "\n",
     "We can use this beta-distribution to calculate the significance of a peak found in the PDM periodogram, or to set a detection threshold. In stingray, this is implemented in the `stingray.stats` module, using `stingray.stats.phase_dispersion_detection_level` and `stingray.stats.phase_dispersion_probability`:\n",
     "\n"
@@ -320,7 +320,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
There were some undefined references in the PDM notebook that leads sphinx to crash in the stingray docs build. this should fix it.