### PR TITLE
Fix location of bexvar() method uses UltraNest md

### DIFF
--- a/Bexvar/Bexvar tutorial.ipynb
+++ b/Bexvar/Bexvar tutorial.ipynb
@@ -93,6 +93,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `bexvar()` method uses [UltraNest](https://johannesbuchner.github.io/UltraNest/) python package to obtain the posteriors of bexvar. Ultranest gives a brief summary of log evidence (log(z)) and its uncertainties, and the parameter constraints.  \n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
@@ -130,13 +137,6 @@
     "\n",
     " bexvar_distribution = bexvar.bexvar(time=time, src_counts=counts, time_del=time_del, frac_exp=frac_exp,\n",
     "                                     bg_counts=bg_counts, bg_ratio=bg_ratio)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `bexvar()` method uses [UltraNest](https://johannesbuchner.github.io/UltraNest/) python package to obtain the posteriors of bexvar. Ultranest gives a brief summary of log evidence (log(z)) and its uncertainties, and the parameter constraints.  \n"
    ]
   },
   {
@@ -275,7 +275,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.10 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -289,9 +289,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.12"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "f6246b25e200e4c5124e3e61789ac81350562f0761bbcf92ad9e48654207659c"
@@ -299,5 +298,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
As mentioned in the documentation, the bexvar() method uses UltraNest python package to obtain the posteriors of bexvar. In a typical install of stingray, it is not required to install the UltraNest dependency. As a result the code fails saying missing dependency UltraNest. 
The markdown mentioning that bexvar() uses UltraNest should be above the code:
bexvar_distribution = bexvar.bexvar(time=time, src_counts=counts, time_del=time_del, frac_exp=frac_exp,
                                     bg_counts=bg_counts, bg_ratio=bg_ratio)
This will ensure that the user knows beforehand about the missing dependency.