### PR TITLE
Spelling correct from Lingcurve to Lightcurve

### DIFF
--- a/CrossCorrelation/cross_correlation_notebook.ipynb
+++ b/CrossCorrelation/cross_correlation_notebook.ipynb
@@ -529,7 +529,7 @@
     "collapsed": true
    },
    "source": [
-    "## Yet another Example with longer Lingcurve\n",
+    "## Yet another Example with longer Lightcurve\n",
     "\n",
     "I will be using same lightcurves as in the example above but with much longer duration and shorter lags.<br>\n",
     "Both Lightcurves are chosen to be more or less same with a certain phase shift to demonstrate Correlation in a better way.\n",


### PR DESCRIPTION
Just a simple spelling correction.