### PR TITLE
Change the wrong variable name from uniform_window to window

### DIFF
--- a/Window Functions/window_functions.ipynb
+++ b/Window Functions/window_functions.ipynb
@@ -149,7 +149,7 @@
    ],
    "source": [
     "nfft = 2048\n",
-    "A = fft(uniform_window,nfft ) / (len(uniform_window)/2.0)\n",
+    "A = fft(window,nfft ) / (len(window)/2.0)\n",
     "freq = fftfreq(nfft)\n",
     "response = 20 * np.log10(np.abs(fftshift(A/(abs(A).max()))))\n",
     "plt.plot(freq, response)\n",


### PR DESCRIPTION
The first create_window object that is the uniform window was given the variable name window. However afterwards, the code tried to call it by the name uniform_window.
So I changed that uniform_window to window in :
A = fft(window,nfft ) / (len(window)/2.0)

Now the code doesn't give any errors.
The variable name was not instead corrected to uniform_window to maintain consistency like in all other create_window objects examples.