### PR TITLE
np.int is deprecated and int should be used

### DIFF
--- a/Deadtime/Check FAD correction in Stingray.ipynb
+++ b/Deadtime/Check FAD correction in Stingray.ipynb
@@ -70,7 +70,7 @@
     "tstart = 0\n",
     "length = 25600\n",
     "segment_size = 256.\n",
-    "ncounts = np.int(ctrate * length)\n",
+    "ncounts = int(ctrate * length)\n",
     "ev1 = EventList(generate_events(length, ncounts), mjdref=58000, gti=[[tstart, length]])\n",
     "ev2 = EventList(generate_events(length, ncounts), mjdref=58000, gti=[[tstart, length]])\n",
     "\n",


### PR DESCRIPTION
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.

Just changed np.int to int.