### PR TITLE
Lightcurve notebook correction

### DIFF
--- a/Lightcurve/Lightcurve tutorial.ipynb
+++ b/Lightcurve/Lightcurve tutorial.ipynb
@@ -1770,7 +1770,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "start_times, stop_times, lc_sums = lc.analyze_lc_chunks(chunk_length = 10.0, func=np.median)"
+    "start_times, stop_times, lc_sums = lc.analyze_lc_chunks(segment_size = 10.0, func=np.median)"
    ]
   },
   {
@@ -1820,7 +1820,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "start_times, stop_times, lc_result = lc.analyze_lc_chunks(chunk_length=10.0, func=myfunc)"
+    "start_times, stop_times, lc_result = lc.analyze_lc_chunks(segment_size=10.0, func=myfunc)"
    ]
   },
   {

--- a/Lightcurve/Lightcurve tutorial.ipynb
+++ b/Lightcurve/Lightcurve tutorial.ipynb
@@ -1850,7 +1850,7 @@
    "source": [
     "## Compatibility with `Lightkurve`\n",
     "\n",
-    "The [`Lightkurve` package](https://docs.lightkurve.org) provides a large amount of complementary functionality to stingray, in particular for data observed with Kepler and TESS, stars and exoplanets, and unevenly sampled data. We have implemented a conversion method that converts to/from `stingray`'s native `Lightcurve` object and `Lightkurve`'s native `LightCurve` object. Equivalent functionality exists in `Lightkurve`, too. "
+    "The [`Lightkurve` package](https://docs.lightkurve.org) provides a large amount of complementary functionality to stingray, in particular for data observed with Kepler and TESS, stars and exoplanets, and unevenly sampled data. We have implemented a conversion method that converts to/from `stingray`'s native `Lightcurve` object and `Lightkurve`'s native `LightCurve` object. Equivalent functionality exists in `Lightkurve`, too. The users who have not installed Lightkurve package should do so first by running *pip install lightkurve* in their terminal and then following with the next command."
    ]
   },
   {


### PR DESCRIPTION
Two corrections in Lightcurve notebook.
1) Replaced chunk_length parameter with segment_size
2) Added reminder to use pip install lightkurve