### PR TITLE
Lomb Scargle

### DIFF
--- a/LombScargle/LombScargleCrossspectrum_tutorial.ipynb
+++ b/LombScargle/LombScargleCrossspectrum_tutorial.ipynb
@@ -143,10 +143,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
     "lcs = LombScargleCrossspectrum(\n",
     "    lc1,\n",
     "    lc2,\n",
-    "    min_freq=0,\n",
+    "    min_freq=sys.float_info.epsilon,\n",
     "    max_freq=None,\n",
     "    method=\"fast\",\n",
     "    power_type=\"all\",\n",
@@ -300,9 +301,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/LombScargle/LombScarglePowerspectrum_tutorial.ipynb
+++ b/LombScargle/LombScarglePowerspectrum_tutorial.ipynb
@@ -123,9 +123,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
     "lps = LombScarglePowerspectrum(\n",
     "    lc,\n",
-    "    min_freq=0,\n",
+    "    min_freq=sys.float_info.epsilon,\n",
     "    max_freq=None,\n",
     "    method=\"fast\",\n",
     "    power_type=\"all\",\n",


### PR DESCRIPTION
As in the LombScargleCrossspectrum method, the parameter min_freq was set to 0 which gave this warning:
/Users/kartikmandar/Desktop/GSOC/stingray/stingray/lombscargle.py:66: UserWarning: min_freq must be positive and >0. Setting to df / 2.
  warnings.warn("min_freq must be positive and >0. Setting to df / 2.")
  
  So I set up the min. possible positive float value as the min_freq. I hope that it's not undesirable?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/StingraySoftware/notebooks/95)
<!-- Reviewable:end -->
