### PR TITLE
Fix set_xdata scalar bug in InteractivePhaseogram (issue #802)

### DIFF
--- a/Pulsar/Pulsar search with epoch folding and Z squared.ipynb
+++ b/Pulsar/Pulsar search with epoch folding and Z squared.ipynb
@@ -8,8 +8,7 @@
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-     ]
+     "text": []
     }
    ],
    "source": [
@@ -398,8 +397,7 @@
     {
      "name": "stderr",
      "output_type": "stream",
-     "text": [
-     ]
+     "text": []
     }
    ],
    "source": [
@@ -827,9 +825,9 @@
     "                phaseogram(self.ev_times, self.freq, fdot=self.fdot, plot=False, \n",
     "                           nph=self.nph, nt=self.nt, pepoch=pepoch)\n",
     "        \n",
-    "        self.l1.set_xdata(0.5)\n",
-    "        self.l2.set_xdata(1)\n",
-    "        self.l3.set_xdata(1.5)\n",
+    "        self.l1.set_xdata(np.zeros_like(self.times) + 0.5)\n",
+    "        self.l2.set_xdata(np.ones_like(self.times))\n",
+    "        self.l3.set_xdata(np.ones_like(self.times) + 0.5)\n",
     "\n",
     "        self.sfreq.reset()\n",
     "        self.sfdot.reset()\n",
@@ -844,9 +842,9 @@
     "        self.sfdot.reset()\n",
     "        self.spepoch.reset()\n",
     "        self.pcolor.set_array(self.phaseogr.T.ravel())\n",
-    "        self.l1.set_xdata(0.5)\n",
-    "        self.l2.set_xdata(1)\n",
-    "        self.l3.set_xdata(1.5)\n",
+    "        self.l1.set_xdata(np.zeros_like(self.times) + 0.5)\n",
+    "        self.l2.set_xdata(np.ones_like(self.times))\n",
+    "        self.l3.set_xdata(np.ones_like(self.times) + 0.5)\n",
     "    \n",
     "    def get_values(self):\n",
     "        return self.freq, self.fdot"


### PR DESCRIPTION
## Summary

Companion PR to StingraySoftware/stingray#964

Fixes StingraySoftware/stingray#802

### Problem

In `InteractivePhaseogram.recalculate()` and `.reset()` in the Pulsar notebook, `set_xdata()` was called with bare scalars (`0.5`, `1`, `1.5`). Modern matplotlib requires array-like input, causing a `TypeError`.

### Fix

Replace scalar arguments with array expressions matching the shape of `self.times`:

```python
# Before (broken)
self.l1.set_xdata(0.5)
self.l2.set_xdata(1)
self.l3.set_xdata(1.5)

# After (fixed)
self.l1.set_xdata(np.zeros_like(self.times) + 0.5)
self.l2.set_xdata(np.ones_like(self.times))
self.l3.set_xdata(np.ones_like(self.times) + 0.5)
```

Applied in both `recalculate()` and `reset()` methods (6 lines total).

### Validation

- Fix is consistent with how the lines are initialized in `__init__` (which already uses `np.zeros_like`/`np.ones_like`)
- Minimal diff - no notebook outputs re-generated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/StingraySoftware/notebooks/126)
<!-- Reviewable:end -->
